### PR TITLE
Fixing ubuntu ifdown error for ens3

### DIFF
--- a/config-drive/master_config.sh
+++ b/config-drive/master_config.sh
@@ -8,7 +8,9 @@ export SYSTEM_URL=https://github.com/Mirantis/reclass-system-salt-model.git
 
 echo "Configuring network interfaces"
 envsubst < /root/interfaces > /etc/network/interfaces
-ifdown ens3; ifup ens3
+ip a flush dev ens3
+rm /var/run/network/ifstate.ens3
+ifup ens3
 
 echo "Preparing metadata model"
 mount /dev/cdrom /mnt/

--- a/config-drive/mirror_config.sh
+++ b/config-drive/mirror_config.sh
@@ -7,7 +7,9 @@ export APTLY_MINION_ID=apt01.deploy-name.local
 
 echo "Configuring network interfaces"
 envsubst < /root/interfaces > /etc/network/interfaces
-ifdown ens3; ifup ens3
+ip a flush dev ens3
+rm /var/run/network/ifstate.ens3
+ifup ens3
 
 echo "Configuring salt"
 service salt-minion stop


### PR DESCRIPTION
Ubuntu ifdown script cannot handle old address when it was wiped
from /etc/network/interfaces
It fails and causes
RTNETLINK answers: No such process
RTNETLINK answers: Cannot assign requested address
error.

This patch fixes this behavior by:
1) proper flushing all the addresses from ens3
2) removing ifstate flag, so further ifup script could set it up.