### PR TITLE
Ensure ens3 configuration, gateway fix

### DIFF
--- a/config-drive/master_config.sh
+++ b/config-drive/master_config.sh
@@ -9,7 +9,10 @@ export SYSTEM_URL=https://github.com/Mirantis/reclass-system-salt-model.git
 echo "Configuring network interfaces"
 envsubst < /root/interfaces > /etc/network/interfaces
 ip a flush dev ens3
-rm /var/run/network/ifstate.ens3
+rm -f /var/run/network/ifstate.ens3
+if [[ $(grep -E '^\ *gateway\ ' /etc/network/interfaces) ]]; then
+(ip r s | grep ^default) && ip r d default || /bin/true
+fi;
 ifup ens3
 
 echo "Preparing metadata model"

--- a/config-drive/mirror_config.sh
+++ b/config-drive/mirror_config.sh
@@ -8,7 +8,10 @@ export APTLY_MINION_ID=apt01.deploy-name.local
 echo "Configuring network interfaces"
 envsubst < /root/interfaces > /etc/network/interfaces
 ip a flush dev ens3
-rm /var/run/network/ifstate.ens3
+rm -f /var/run/network/ifstate.ens3
+if [[ $(grep -E '^\ *gateway\ ' /etc/network/interfaces) ]]; then
+(ip r s | grep ^default) && ip r d default || /bin/true
+fi;
 ifup ens3
 
 echo "Configuring salt"


### PR DESCRIPTION
1) Ensforce state removal regardless of its existence
2) In case when gateway is set in /etc/network/interfaces for ens3
ifup ens3 may fail when default is already in use/set
Ensure default gateway removed before ifup ens3 called.